### PR TITLE
change mode of view-screen unification

### DIFF
--- a/Implementation/Bounded.swift
+++ b/Implementation/Bounded.swift
@@ -7,11 +7,29 @@ import UIKit
 // This interface gives us a common language to talk to objects that have a coordinateSpace, and bounds.  We use it in tests where we want to test layout.  Sometimes, a layout requirement
 // is about a view being laid out relative to the screen.  Other times, a layout requirement is about a view being laid out relative to another view.  This way, we can ignore the
 // distinction, and write the test in terms of how two bounds, translated to common coordinate system, relate to each other.
-public protocol Bounded {
 
-    var coordinateSpace: UICoordinateSpace { get }
-    var bounds: CGRect { get }
+public enum ViewOrScreen {
+    case view(UIView)
+    case screen(UIScreen)
+    public var bounds : CGRect {
+        switch self {
+        case .view(let v): return v.bounds
+        case .screen(let s): return s.coordinateSpace.bounds
+        }
+    }
 }
 
-extension UIScreen : Bounded { }
-extension UIView : Bounded { }
+public extension UIView {
+    func convert(_ point: CGPoint, to vos: ViewOrScreen) -> CGPoint {
+        switch vos {
+        case .view(let v): return self.convert(point, to:v)
+        case .screen(let s): return self.convert(point, to:s.coordinateSpace)
+        }
+    }
+    func convert(_ point: CGPoint, from vos: ViewOrScreen) -> CGPoint {
+        switch vos {
+        case .view(let v): return self.convert(point, from:v)
+        case .screen(let s): return self.convert(point, from:s.coordinateSpace)
+        }
+    }
+}

--- a/Tests/Acceptance/RestaurantMenuTests.swift
+++ b/Tests/Acceptance/RestaurantMenuTests.swift
@@ -28,7 +28,7 @@ class RestaurantMenuAcceptanceTests: BDDTest {
     // production code and make sure it handles them correctly.
     func testMenuActivityLogoLayout() {
 
-        let screens = (0..<10).map { i -> UIScreenMock in given.screen() }
+        let screens : [UIScreenMock] = (0..<10).map { _ in given.screen() }
 
         for screen in screens {
 
@@ -38,9 +38,9 @@ class RestaurantMenuAcceptanceTests: BDDTest {
 
             when.activityIsLaidOutIn(rma, screen)
 
-            then.topsShouldEqual(liv, screen)
-            then.leftsShouldEqual(liv, screen)
-            then.rightsShouldEqual(liv, screen)
+            then.topsShouldEqual(liv, .screen(screen))
+            then.leftsShouldEqual(liv, .screen(screen))
+            then.rightsShouldEqual(liv, .screen(screen))
             then.aspectRatiosShouldEqual(liv, li)
         }
     }
@@ -57,10 +57,10 @@ class RestaurantMenuAcceptanceTests: BDDTest {
 
             when.activityIsLaidOutIn(rma, screen)
 
-            then.topShouldEqualBottom(rml, liv)
-            then.leftsShouldEqual(rml, screen)
-            then.rightsShouldEqual(rml, screen)
-            then.bottomsShouldEqual(rml, screen)
+            then.topShouldEqualBottom(rml, .view(liv))
+            then.leftsShouldEqual(rml, .screen(screen))
+            then.rightsShouldEqual(rml, .screen(screen))
+            then.bottomsShouldEqual(rml, .screen(screen))
         }
     }
 }

--- a/Tests/Steps/ThenSteps.swift
+++ b/Tests/Steps/ThenSteps.swift
@@ -105,30 +105,30 @@ class ThenSteps {
         XCTAssertEqual(viewModel.items, expectedItems, "Menu items are not equal")
     }
 
-    func topsShouldEqual(_ first: UIView, _ second: Bounded) {
+    func topsShouldEqual(_ first: UIView, _ second: ViewOrScreen) {
 
-        let firstTop = first.convert(first.bounds.origin, to: second.coordinateSpace).y
+        let firstTop = first.convert(first.bounds.origin, to: second).y
         let secondTop = second.bounds.minY
         XCTAssertTrue(comparePoints(first: firstTop, second: secondTop), "tops are not equal")
     }
 
-    func leftsShouldEqual(_ first: UIView, _ second: Bounded) {
+    func leftsShouldEqual(_ first: UIView, _ second: ViewOrScreen) {
 
-        let firstLeft = first.convert(first.bounds.origin, to: second.coordinateSpace).x
+        let firstLeft = first.convert(first.bounds.origin, to: second).x
         let secondLeft = second.bounds.minX
         XCTAssertTrue(comparePoints(first: firstLeft, second: secondLeft), "lefts are not equal")
     }
 
-    func rightsShouldEqual(_ first: UIView, _ second: Bounded) {
+    func rightsShouldEqual(_ first: UIView, _ second: ViewOrScreen) {
 
-        let firstRight = first.convert(first.bounds.origin, to: second.coordinateSpace).x + first.frame.size.width
+        let firstRight = first.convert(first.bounds.origin, to: second).x + first.frame.size.width
         let secondRight = second.bounds.maxX
         XCTAssertTrue(comparePoints(first: firstRight, second: secondRight), "rights are not equal")
     }
 
-    func topShouldEqualBottom(_ first: UIView, _ second: Bounded) {
+    func topShouldEqualBottom(_ first: UIView, _ second: ViewOrScreen) {
 
-        let firstTop = first.convert(first.bounds.origin, to: second.coordinateSpace).y
+        let firstTop = first.convert(first.bounds.origin, to: second).y
         let secondBottom = second.bounds.maxY
 
         if(!comparePoints(first: firstTop, second: secondBottom)) {
@@ -143,9 +143,9 @@ class ThenSteps {
         XCTAssertEqual(rml.viewModel.items, menuItems, "Menu items are not equal")
     }
 
-    func bottomsShouldEqual(_ first: UIView, _ second: Bounded) {
+    func bottomsShouldEqual(_ first: UIView, _ second: ViewOrScreen) {
 
-        XCTAssertEqual(first.convert(first.bounds.origin, to: second.coordinateSpace).y + first.frame.size.height, second.bounds.maxY, "bottoms are not equal")
+        XCTAssertEqual(first.convert(first.bounds.origin, to: second).y + first.frame.size.height, second.bounds.maxY, "bottoms are not equal")
     }
 
     func comparePoints(first: CGFloat, second: CGFloat) -> Bool {


### PR DESCRIPTION
Okay, this one is rather sweeping so I'd better add some justification.

The idea is to unify UIView and UIScreen for purposes of point conversion for checking layout. One might argue that this was never necessary and that the use of the UIScreen subclass UIScreenMock was always a red herring; but let's go with the flow. From the outset, then, two things concerned me about the way this unification was being done:

* A UIView does not "really" have a coordinate space. That property is a tvOS property that has sort of accidentally lapsed over into iOS; it has to do with Focus. It has no real meaning or purpose in iOS and should not be relied on.
* There is a nasty impedance mismatch between talking about the `coordinateSpace` of a UIScreen, on the one hand, and its `bounds`, on the other. This might appear to work, but the whole point of `coordinateSpace` is to provide a consistent coordinate world that works even in rotation etc. Therefore when UIScreen acquired a `coordinateSpace` property, it also acquired the `bounds` _of the `coordinateSpace`,_ superseding the old `bounds`, which should no longer be used as it is ambiguous. Thus the code here should be consistent in referring to `coordinateSpace.bounds`, and _not_ simple `bounds`, when talking to the UIScreen.

To take care of both these things, I've taken a completely different approach to unification, namely a Union — an enum with two cases with associated values. This allows me to pass an instance of the enum where previously we were passing Bounded. The enum routes `bounds` getters to the correct place (`bounds` of a view, but `coordinateSpace.bounds` of a screen). UIView is then endowed with `convert(to)` and `convert(from)` methods that take the enum as param. The test code itself thus no longer has to concern itself with the notion of a coordinate space at all.